### PR TITLE
ci: fix ObjectBox test dependencies

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -69,7 +69,7 @@ scripts:
 
   test:
     description: Run `dart test` in vm, chrome and flutter in the selected packages
-    run: melos run test:vm && melos run test:chrome && melos run test:flutter
+    run: melos run install && melos run test:vm && melos run test:chrome && melos run test:flutter
   
   test:vm:
     description: Run `dart test -p vm` in the selected packages.
@@ -91,7 +91,7 @@ scripts:
 
   coverage:
     description: Run `dart test` in vm and chrome and collects coverage.
-    run: melos run coverage:vm && melos run coverage:chrome && melos run coverage:flutter
+    run: melos run install && melos run coverage:vm && melos run coverage:chrome && melos run coverage:flutter
 
   coverage:vm:
     description: Run `dart test -p vm` in the selected packages and collects coverage.


### PR DESCRIPTION
## Summary
- install ObjectBox libraries before running tests and coverage

## Testing
- `dart test -p vm test/objectbox/objectbox_store_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_6861a8a11ab88331a0ac470c6a67e7d1